### PR TITLE
GEODE-8842: Limit no-used-but-marked-unused to new integration tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     -Wextra
     -Wno-unused-variable #TODO fix
     -Wno-unused-function #TODO fix
-    -Wno-used-but-marked-unused #TODO fix
     -Wpedantic
     -Weverything
     -Wno-non-virtual-dtor #TODO fix

--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -16,6 +16,7 @@
 add_executable(cpp-integration-test
   AuthInitializeTest.cpp
   BasicIPv6Test.cpp
+  CacheWriterTest.cpp
   CacheXmlTest.cpp
   CleanIdleConnections.cpp
   ClientTransactionXATest.cpp
@@ -30,12 +31,13 @@ add_executable(cpp-integration-test
   FunctionExecutionTest.cpp
   LRUEvictionTest.cpp
   LocatorRequestsTest.cpp
+  Order.cpp
+  Order.hpp
   PartitionRegionOpsTest.cpp
+  PdxInstanceFactoryTest.cpp
   PdxInstanceTest.cpp
   PdxJsonTypeTest.cpp
   PdxSerializerTest.cpp
-  Order.cpp
-  Order.hpp
   Position.cpp
   Position.hpp
   PositionKey.cpp
@@ -53,11 +55,15 @@ add_executable(cpp-integration-test
   SslTwoWayTest.cpp
   StructTest.cpp
   TransactionCleaningTest.cpp
-  WanDeserializationTest.cpp
-  PdxInstanceFactoryTest.cpp
-  CacheWriterTest.cpp
   TransactionsTest.cpp
+  WanDeserializationTest.cpp
 )
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(cpp-integration-test
+    PUBLIC
+      -Wno-used-but-marked-unused
+  )
+endif()
 
 target_compile_definitions(cpp-integration-test
   PUBLIC


### PR DESCRIPTION
- SCOPED_TRACE in gtest causes this error, so only allow in that scope

Authored-by: M. Oleske <michael@oleske.engineer>